### PR TITLE
Removed Dask client definition, used Dask in svd_decompose_design_matrix

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -17,7 +17,6 @@ import os.path
 import warnings
 
 import dask.array as da
-from dask.distributed import Client
 import numpy as np
 import numbers
 from scipy import linalg
@@ -291,14 +290,7 @@ def _solve_cholesky_kernel(K, y, alpha, sample_weight=None, copy=False):
 
 
 def _solve_svd(X, y, alpha):
-    client = Client(
-        os.getenv("DASK_SCHEDULER_ADDRESS", None)
-    )
-    print(
-            "[INFO] scikit-learn dask client conneted to scheduler:",
-              client.scheduler.address
-    )
-    U, s, Vt = da.linalg.svd(da.from_array(X)).compute()
+    U, s, Vt = da.linalg.svd(da.from_array(X))
     idx = s > 1e-15  # same default value as scipy.linalg.pinv
     s_nnz = s[idx][:, np.newaxis]
     UTy = np.dot(U.T, y)
@@ -1922,7 +1914,7 @@ class _RidgeGCV(LinearModel):
             # by centering, the other columns are orthogonal to that one
             intercept_column = sqrt_sw[:, None]
             X = np.hstack((X, intercept_column))
-        U, singvals, _ = linalg.svd(X, full_matrices=0)
+        U, singvals, _ = da.linalg.svd(da.from_array(X))
         singvals_sq = singvals**2
         UT_y = np.dot(U.T, y)
         return X_mean, singvals_sq, U, UT_y


### PR DESCRIPTION
Hi @mathdugre, it turns out that RidgeCV was calling a different function than the one you had modified to use Dask. This PR:
* Uses Dask in the function called by RidgeCV as well
* Removes the Client definition that should be done outside of sklearn
* Removes the call to `compute()` as it doesn't seem to be necessary.

Let me know what you think! If this version works, we should find a way to implement it nicely in scikit-learn, the current version is quite brutal :)